### PR TITLE
data-module attribute bug

### DIFF
--- a/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsSkipLink.razor
+++ b/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsSkipLink.razor
@@ -5,34 +5,39 @@
     main content on a page.
 </summary> *@
 
-<AnchorLink 
-    Classes=@classes 
-    Href=@Href 
-    Attributes=@linkAttributes 
-    DataTestId=@DataTestId>
-    @ChildContent
+<AnchorLink Classes=@classes
+			Href=@Href
+			Attributes=@Attributes
+			DataTestId=@DataTestId>
+	@ChildContent
 </AnchorLink>
 
 @code {
-    #region Private Properties
-    private string classes
-    {
-        get
-        {          
-            var classBuilder = "govuk-skip-link";
-            if (!string.IsNullOrEmpty(Classes)) classBuilder += $" {Classes}";
-            return classBuilder;
-        }
-    }
+	#region Private Properties
+	private string classes
+	{
+		get
+		{
+			var classBuilder = "govuk-skip-link";
+			if (!string.IsNullOrEmpty(Classes)) classBuilder += $" {Classes}";
+			return classBuilder;
+		}
+	}
 
-    private Dictionary<string, object> linkAttributes
-    {
-        get
-        {
-            Attributes!.Add("data-module", "govuk-skip-link");
+	protected override async Task OnInitializedAsync()
+	{
+		if (Attributes is null)
+		{
+			Attributes = new Dictionary<string, object>{
+				{"data-module", "govuk-skip-link" }
+			};
+			return;
+		}
 
-            return Attributes!;
-        }
-    }
-    #endregion
+		if (Attributes.ContainsKey("data-module"))
+			return;
+
+		Attributes.Add("data-module", "govuk-skip-link");
+	}
+	#endregion
 }

--- a/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsSkipLink.razor
+++ b/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsSkipLink.razor
@@ -6,9 +6,9 @@
 </summary> *@
 
 <AnchorLink Classes=@classes
-			Href=@Href
-			Attributes=@Attributes
-			DataTestId=@DataTestId>
+Href=@Href
+Attributes=@Attributes
+DataTestId=@DataTestId>
 	@ChildContent
 </AnchorLink>
 
@@ -26,6 +26,8 @@
 
 	protected override async Task OnInitializedAsync()
 	{
+		await base.OnInitializedAsync();
+
 		if (Attributes is null)
 		{
 			Attributes = new Dictionary<string, object>{

--- a/Opss.DesignSystem.Frontend.Blazor.Components/wwwroot/js/init.js
+++ b/Opss.DesignSystem.Frontend.Blazor.Components/wwwroot/js/init.js
@@ -1,4 +1,6 @@
 ﻿function initGOVUKFrontend() {
-    window.GOVUKFrontend.initAll();
-    window.MOJFrontend.initAll()
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+        window.GOVUKFrontend.initAll();
+        window.MOJFrontend.initAll()
+    }
 }

--- a/Opss.DesignSystem.Frontend.Blazor.Showcase/Pages/_Layout.cshtml
+++ b/Opss.DesignSystem.Frontend.Blazor.Showcase/Pages/_Layout.cshtml
@@ -15,7 +15,7 @@
 
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>
-<body class="govuk-frontend-supported govuk-template__body">
+<body class="govuk-template__body">
     <script>
         document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
     </script>

--- a/Opss.DesignSystem.Frontend.Blazor.Showcase/Shared/MainLayout.razor
+++ b/Opss.DesignSystem.Frontend.Blazor.Showcase/Shared/MainLayout.razor
@@ -7,7 +7,7 @@
 <script>
     document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
 </script>
-<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+<GdsSkipLink Href="#main-content">Skip to main content</GdsSkipLink>
 <header class="govuk-header" data-module="govuk-header" @ref=AppHeader>
     <div class="govuk-header__container app-width-container app-header__container">
         <div class="govuk-header__logo">

--- a/Opss.DesignSystem.Frontend.Blazor.Showcase/wwwroot/js/init.js
+++ b/Opss.DesignSystem.Frontend.Blazor.Showcase/wwwroot/js/init.js
@@ -1,4 +1,6 @@
 ﻿function initGOVUKFrontend() {
-    window.GOVUKFrontend.initAll();
-    window.MOJFrontend.initAll()
+    if (!document.body.classList.contains('govuk-frontend-supported')) {
+        window.GOVUKFrontend.initAll();
+        window.MOJFrontend.initAll()
+    }
 }


### PR DESCRIPTION
The data-module attribute was being added on each component render, thus causing Blazor to throw an exception. This update ensures the key is only added once.