### PR TITLE
Fix to Attributes parameter

### DIFF
--- a/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsLink.razor
+++ b/Opss.DesignSystem.Frontend.Blazor.Components/Shared/GdsLink.razor
@@ -48,8 +48,12 @@
         {
             if (OpenInNewTab) 
             {
-                Attributes!.Add("target", "_blank");
-                Attributes!.Add("rel", "noreferrer noopener");
+                var attr = Attributes;
+
+                attr!.Add("target", "_blank");
+                attr!.Add("rel", "noreferrer noopener");
+
+                return attr;
             }
 
             return Attributes!;


### PR DESCRIPTION
Instead of adding items to the Attributes which causes a duplicate key exception when user action occurs, return the Attributes array with new key/values without modifying the original collection.